### PR TITLE
Add Vue 3 + Vite skeleton

### DIFF
--- a/frutale-frontend/.env
+++ b/frutale-frontend/.env
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:3000/api

--- a/frutale-frontend/index.html
+++ b/frutale-frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Frutale</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/frutale-frontend/package.json
+++ b/frutale-frontend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "frutale-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "serve": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.4.21",
+    "axios": "^1.6.0",
+    "vue-router": "^4.2.5"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.1",
+    "vite": "^5.0.8"
+  }
+}

--- a/frutale-frontend/src/App.vue
+++ b/frutale-frontend/src/App.vue
@@ -1,0 +1,12 @@
+<template>
+  <RouterView />
+</template>
+
+<script setup>
+</script>
+
+<style>
+body {
+  font-family: Arial, sans-serif;
+}
+</style>

--- a/frutale-frontend/src/main.js
+++ b/frutale-frontend/src/main.js
@@ -1,0 +1,5 @@
+import { createApp } from 'vue'
+import App from './App.vue'
+import router from './router'
+
+createApp(App).use(router).mount('#app')

--- a/frutale-frontend/src/router/index.js
+++ b/frutale-frontend/src/router/index.js
@@ -1,0 +1,15 @@
+import { createRouter, createWebHistory } from 'vue-router'
+import DashboardView from '../views/DashboardView.vue'
+import PedidosView from '../views/PedidosView.vue'
+
+const routes = [
+  { path: '/', component: DashboardView },
+  { path: '/pedidos', component: PedidosView }
+]
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes
+})
+
+export default router

--- a/frutale-frontend/src/services/api.js
+++ b/frutale-frontend/src/services/api.js
@@ -1,0 +1,8 @@
+import axios from 'axios'
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:3000/api',
+  timeout: 5000
+})
+
+export default api

--- a/frutale-frontend/src/views/DashboardView.vue
+++ b/frutale-frontend/src/views/DashboardView.vue
@@ -1,0 +1,22 @@
+<template>
+  <div>
+    <h1>Dashboard</h1>
+    <p>{{ message }}</p>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import api from '../services/api'
+
+const message = ref('Cargando...')
+
+onMounted(async () => {
+  try {
+    const { data } = await api.get('/dashboard')
+    message.value = data.message
+  } catch (err) {
+    message.value = 'Error al conectar con la API'
+  }
+})
+</script>

--- a/frutale-frontend/src/views/PedidosView.vue
+++ b/frutale-frontend/src/views/PedidosView.vue
@@ -1,0 +1,8 @@
+<template>
+  <div>
+    <h1>Pedidos</h1>
+  </div>
+</template>
+
+<script setup>
+</script>

--- a/frutale-frontend/vite.config.js
+++ b/frutale-frontend/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()],
+  server: {
+    port: 5173
+  }
+})


### PR DESCRIPTION
## Summary
- scaffold new Vue 3 + Vite frontend in `frutale-frontend`
- include router, Axios service, and basic dashboard/pedidos views
- add environment variable for API URL

## Testing
- `npm install` *(fails: 403 Forbidden due to registry access restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_685897c4274483339e0e59351c312486